### PR TITLE
update refs after moving repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,10 +9,10 @@ assignees: ''
 
 If possible choose the correct project:
 
-- [main-repo](https://github.com/orgua/shepherd/issues)
-- [datalib](https://github.com/orgua/shepherd-datalib/issues)
-- [targets](https://github.com/orgua/shepherd-targets/issues)
-- [webapi](https://github.com/orgua/shepherd_webservice/issues)
+- [main-repo](https://github.com/nes-lab/shepherd/issues)
+- [user-tools](https://github.com/nes-lab/shepherd-tools/issues)
+- [targets-repo](https://github.com/nes-lab/shepherd-targets/issues)
+- [webApi](https://github.com/nes-lab/shepherd-webapi/issues)
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,10 +9,10 @@ assignees: ''
 
 If possible choose the correct project:
 
-- [main-repo](https://github.com/nes-lab/shepherd/issues)
-- [user-tools](https://github.com/nes-lab/shepherd-tools/issues)
-- [targets-repo](https://github.com/nes-lab/shepherd-targets/issues)
-- [webApi](https://github.com/nes-lab/shepherd-webapi/issues)
+- [main-repo](https://github.com/nes-lab/shepherd/issues) - infrastructure for the measurement process, emulation and observer-hardware
+- [user-tools](https://github.com/nes-lab/shepherd-tools/issues) - everything related to the data processing toolchain
+- [targets-repo](https://github.com/nes-lab/shepherd-targets/issues) - HW & SW for the cyber-physical systems running within the emulated energy environments
+- [webApi](https://github.com/nes-lab/shepherd-webapi/issues) - the interface between the testbed instance and the user
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,10 +9,10 @@ assignees: ''
 
 If possible choose the correct project:
 
-- [main-repo](https://github.com/orgua/shepherd/issues)
-- [datalib](https://github.com/orgua/shepherd-datalib/issues)
-- [targets](https://github.com/orgua/shepherd-targets/issues)
-- [webapi](https://github.com/orgua/shepherd_webservice/issues)
+- [main-repo](https://github.com/nes-lab/shepherd/issues)
+- [user-tools](https://github.com/nes-lab/shepherd-tools/issues)
+- [targets-repo](https://github.com/nes-lab/shepherd-targets/issues)
+- [webApi](https://github.com/nes-lab/shepherd-webapi/issues)
 
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,11 +9,10 @@ assignees: ''
 
 If possible choose the correct project:
 
-- [main-repo](https://github.com/nes-lab/shepherd/issues)
-- [user-tools](https://github.com/nes-lab/shepherd-tools/issues)
-- [targets-repo](https://github.com/nes-lab/shepherd-targets/issues)
-- [webApi](https://github.com/nes-lab/shepherd-webapi/issues)
-
+- [main-repo](https://github.com/nes-lab/shepherd/issues) - infrastructure for the measurement process, emulation and observer-hardware
+- [user-tools](https://github.com/nes-lab/shepherd-tools/issues) - everything related to the data processing toolchain
+- [targets-repo](https://github.com/nes-lab/shepherd-targets/issues) - HW & SW for the cyber-physical systems running within the emulated energy environments
+- [webApi](https://github.com/nes-lab/shepherd-webapi/issues) - the interface between the testbed instance and the user
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.10'
+    rev: 'v0.11.11'
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Shepherd - Datalib
+# Shepherd - Tools
 
-[![PyPiVersion](https://img.shields.io/pypi/v/shepherd_data.svg)](https://pypi.org/project/shepherd_data)
+[![PyPIVersion](https://img.shields.io/pypi/v/shepherd_data.svg)](https://pypi.org/project/shepherd_data)
 [![image](https://img.shields.io/pypi/pyversions/shepherd_data.svg)](https://pypi.python.org/pypi/shepherd-data)
-[![QA-Tests](https://github.com/orgua/shepherd-datalib/actions/workflows/quality_assurance.yaml/badge.svg)](https://github.com/orgua/shepherd-datalib/actions/workflows/quality_assurance.yaml)
+[![QA-Tests](https://github.com/nes-lab/shepherd-tools/actions/workflows/quality_assurance.yaml/badge.svg)](https://github.com/nes-lab/shepherd-tools/actions/workflows/quality_assurance.yaml)
 [![CodeStyle](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 **Data-Package**: <https://pypi.org/project/shepherd_data>
 
 **Core-library**: <https://pypi.org/project/shepherd_core>
 
-**Main Documentation**: <https://orgua.github.io/shepherd>
+**Main Documentation**: <https://nes-lab.github.io/shepherd>
 
-**Main Project**: <https://github.com/orgua/shepherd>
+**Main Project**: <https://github.com/nes-lab/shepherd>
 
-**Source Code**: <https://github.com/orgua/shepherd-datalib>
+**Source Code**: <https://github.com/nes-lab/shepherd-tools>
 
 ---
 
-The Repository contains python packages for the [shepherd](https://github.com/orgua/shepherd)-testbed
+The Repository contains python packages for the [shepherd](https://github.com/nes-lab/shepherd)-testbed
 
 - `/shepherd_core` bundles functionality that is used by multiple tools and the community
 - `/shepherd_data` holds the data-module that is designed for users of the testbed
@@ -39,8 +39,8 @@ The environment brings everything needed for dev-work, steps for installing are 
   - add special packages with `-dev` switch
 
 ```Shell
-git clone https://github.com/orgua/shepherd-datalib
-cd .\shepherd-datalib
+git clone https://github.com/nes-lab/shepherd-tools
+cd .\shepherd-tools
 
 pipenv install --dev
 pipenv shell
@@ -51,7 +51,7 @@ pipenv install --dev pytest
 
 ### Update dynamic Fixtures
 
-When external dependencies ([Target-Lib](https://github.com/orgua/shepherd-targets/)) or core-models change, the fixtures should be also updated for the testbed.
+When external dependencies ([Targets-Repo](https://github.com/nes-lab/shepherd-targets/)) or core-models change, the fixtures should be also updated for the testbed.
 
 ```shell
 python3 extra/gen_firmwares.py
@@ -176,6 +176,6 @@ coverage html
   - datatype-hint in h5-file (`ivcurve`, `ivsample`, `isc_voc`), add mechanism to prevent misuse
   - hostname for emulation
   - full and minimal config into h5
-  - use the datalib as a base
+  - use shepherd-core as a base
   - isc-voc-harvesting
   - directly process isc-voc ⇾ resample to ivcurve?

--- a/extra/README.md
+++ b/extra/README.md
@@ -3,7 +3,7 @@
 These scripts are used to fill the database of the testbed-server. Currently, they can:
 
 - generate energy environments and their models
-- generate embedded firmware-models from [another repo](https://github.com/orgua/shepherd-targets)
+- generate embedded firmware-models from the [targets-repo](https://github.com/nes-lab/shepherd-targets)
 - use data-models as fixtures for core-lib
 - create reoccurring experiments / tasks
   - taking the RF-survey to derive a link-matrix

--- a/extra/gen_firmwares.py
+++ b/extra/gen_firmwares.py
@@ -1,6 +1,6 @@
 """This script will download & prepare target-firmwares.
 
-- download and extract firmwares from https://github.com/orgua/shepherd-targets/releases
+- download and extract firmwares from https://github.com/nes-lab/shepherd-targets/releases
 - generate embedded firmware-models
 - it assumes sub-dirs in the same dir with ./build.elf in it
 """
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         path_fw = path_here / "content/fw/nes_lab/"
 
     # config
-    link = "https://github.com/orgua/shepherd-targets/releases/latest/download/firmwares.zip"
+    link = "https://github.com/nes-lab/shepherd-targets/releases/latest/download/firmwares.zip"
     # ⤷ already includes embedded-firmware-models
     path_meta = path_fw / "metadata_fw.yaml"
 

--- a/scratch/proto_content.py
+++ b/scratch/proto_content.py
@@ -1,0 +1,51 @@
+"""
+Goals:
+- add structured metadata
+- allow relative pathing - with real inputs (full Path() to rel)
+- allow list of paths, or even dict, but still slice[:] operation
+"""
+from pathlib import PurePosixPath, Path
+from typing import Annotated, Mapping
+from pydantic import Field
+from shepherd_core.data_models import ContentModel, ShpModel
+
+
+# TODO: should dtype, duration, energy_Ws be kept with the path?
+#       So we would have to create a scalar energy profile
+# TODO: add typecast from WindowPath / PosixPath -> Pure ... pydantic does not support it automatically
+
+class EEnv2(ContentModel):
+
+    metadata: Mapping[str, str] = {}
+
+    #data_path: PurePosixPath
+    data_paths: Annotated[list[PurePosixPath], Field(min_length=1, max_length=128)]
+    repetitions_ok: bool = False
+
+    def __getitem__(self, value):
+        if isinstance(value, slice):
+            print(str(value))
+        if isinstance(value, int):
+            print(str(value))
+
+    def __len__(self) -> int:
+        return len(self.data_paths)
+
+class TargetConfig2(ShpModel):
+
+    target_IDs: Annotated[list[int], Field(min_length=1, max_length=128)]
+    eenvs: list[EEnv2]
+
+
+if __name__ == "__main__":
+
+    eenv = EEnv2(
+        data_paths=[Path(".nagut"), Path("/pagut"), PurePosixPath("spaghetti")],
+        repetitions_ok=True,
+    )
+
+    slice1 = eenv[2]
+    slice2 = eenv[5]
+    slice3 = eenv[1:]
+
+    print("done")

--- a/scratch/proto_content.py
+++ b/scratch/proto_content.py
@@ -1,44 +1,57 @@
-"""
+"""Prototype for an improved EEnv-Dataclass.
+
 Goals:
 - add structured metadata
 - allow relative pathing - with real inputs (full Path() to rel)
 - allow list of paths, or even dict, but still slice[:] operation
+- avoid funky behavior & hidden mechanics
 """
-from pathlib import PurePosixPath, Path
-from typing import Annotated, Mapping
-from pydantic import Field
-from shepherd_core.data_models import ContentModel, ShpModel
 
+from collections.abc import Mapping
+from pathlib import Path
+from pathlib import PurePosixPath
+from typing import Annotated
+from typing import Any
+
+from pydantic import Field
+
+from shepherd_core import logger
+from shepherd_core.data_models import ContentModel
+from shepherd_core.data_models import ShpModel
 
 # TODO: should dtype, duration, energy_Ws be kept with the path?
 #       So we would have to create a scalar energy profile
-# TODO: add typecast from WindowPath / PosixPath -> Pure ... pydantic does not support it automatically
+# TODO: add typecast from WindowPath / PosixPath -> Pure ...
+#       pydantic does not support it automatically
+
 
 class EEnv2(ContentModel):
+    """Prototype."""
 
     metadata: Mapping[str, str] = {}
 
-    #data_path: PurePosixPath
     data_paths: Annotated[list[PurePosixPath], Field(min_length=1, max_length=128)]
     repetitions_ok: bool = False
 
-    def __getitem__(self, value):
+    def __getitem__(self, value: Any) -> "EEnv2":
         if isinstance(value, slice):
-            print(str(value))
+            logger.info(str(value))
         if isinstance(value, int):
-            print(str(value))
+            logger.info(str(value))
+        return self
 
     def __len__(self) -> int:
         return len(self.data_paths)
 
+
 class TargetConfig2(ShpModel):
+    """Prototype."""
 
     target_IDs: Annotated[list[int], Field(min_length=1, max_length=128)]
     eenvs: list[EEnv2]
 
 
 if __name__ == "__main__":
-
     eenv = EEnv2(
         data_paths=[Path(".nagut"), Path("/pagut"), PurePosixPath("spaghetti")],
         repetitions_ok=True,
@@ -48,4 +61,4 @@ if __name__ == "__main__":
     slice2 = eenv[5]
     slice3 = eenv[1:]
 
-    print("done")
+    logger.info("done")

--- a/shepherd_core/README.md
+++ b/shepherd_core/README.md
@@ -1,15 +1,15 @@
 # Core Library
 
-[![PyPiVersion](https://img.shields.io/pypi/v/shepherd_core.svg)](https://pypi.org/project/shepherd_core)
+[![PyPIVersion](https://img.shields.io/pypi/v/shepherd_core.svg)](https://pypi.org/project/shepherd_core)
 [![image](https://img.shields.io/pypi/pyversions/shepherd_core.svg)](https://pypi.python.org/pypi/shepherd-core)
-[![Pytest](https://github.com/orgua/shepherd-datalib/actions/workflows/py_unittest.yml/badge.svg)](https://github.com/orgua/shepherd-datalib/actions/workflows/py_unittest.yml)
+[![QA-Tests](https://github.com/nes-lab/shepherd-tools/actions/workflows/quality_assurance.yaml/badge.svg)](https://github.com/nes-lab/shepherd-tools/actions/workflows/quality_assurance.yaml)
 [![CodeStyle](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-**Main Documentation**: <https://orgua.github.io/shepherd>
+**Main Documentation**: <https://nes-lab.github.io/shepherd>
 
-**Source Code**: <https://github.com/orgua/shepherd-datalib>
+**Source Code**: <https://github.com/nes-lab/shepherd-tools>
 
-**Main Project**: <https://github.com/orgua/shepherd>
+**Main Project**: <https://github.com/nes-lab/shepherd>
 
 ---
 
@@ -31,7 +31,7 @@ For postprocessing shepherds .h5-files usage of [shepherd_data](https://pypi.org
 - decode waveforms (gpio-state & timestamp) to UART
 - create an inventory (for deployed versions of software, hardware)
 
-See [official documentation](https://orgua.github.io/shepherd) or [example scripts](https://github.com/orgua/shepherd-datalib/tree/main/shepherd_core/examples) for more details and usage. Most functionality is showcased in both. The [extra](https://github.com/orgua/shepherd-datalib/tree/main/shepherd_core/extra)-directory holds data-generators relevant for the testbed. Notably is a [trafficbench](https://github.com/orgua/TrafficBench)-experiment that's used to derive the link-matrix of the testbed-nodes.
+See [official documentation](https://nes-lab.github.io/shepherd) or [example scripts](https://github.com/nes-lab/shepherd-tools/tree/main/shepherd_core/examples) for more details and usage. Most functionality is showcased in both. The [extra](https://github.com/nes-lab/shepherd-tools/tree/main/shepherd_core/extra)-directory holds data-generators relevant for the testbed. Notably is a [trafficbench](https://github.com/nes-lab/TrafficBench)-experiment that's used to derive the link-matrix of the testbed-nodes.
 
 ## Config-Models in Detail
 
@@ -89,9 +89,9 @@ pip install shepherd-data -U
 For bleeding-edge-features or dev-work it is possible to install directly from GitHub-Sources (here `dev`-branch):
 
 ```Shell
-pip install git+https://github.com/orgua/shepherd-datalib.git@dev#subdirectory=shepherd_core -U
+pip install git+https://github.com/nes-lab/shepherd-tools.git@dev#subdirectory=shepherd_core -U
 # and on sheep with newer debian
-sudo pip install git+https://github.com/orgua/shepherd-datalib.git@dev#subdirectory=shepherd_core -U --break-system-packages
+sudo pip install git+https://github.com/nes-lab/shepherd-tools.git@dev#subdirectory=shepherd_core -U --break-system-packages
 ```
 
 If you are working with ``.elf``-files (embedding into experiments) you make "objcopy" accessible to python. In Ubuntu, you can either install ``build-essential`` or ``binutils-$ARCH`` with arch being ``msp430`` or ``arm-none-eabi`` for the nRF52.
@@ -123,7 +123,7 @@ To run the testbench, follow these steps:
 3. run the testbench (~ 320 tests):
 
 ```Shell
-cd shepherd-datalib/shepherd_core
+cd shepherd-tools/shepherd_core
 pip3 install ./[tests]
 pytest
 ```

--- a/shepherd_core/pyproject.toml
+++ b/shepherd_core/pyproject.toml
@@ -71,8 +71,8 @@ file = "README.md"
 content-type = "text/markdown"
 
 [project.urls]
-Documentation = "https://github.com/orgua/shepherd-datalib/blob/main/README.md"
-Issues = "https://github.com/orgua/shepherd-datalib/issues"
+Documentation = "https://github.com/nes-lab/shepherd-tools/blob/main/README.md"
+Issues = "https://github.com/nes-lab/shepherd-tools/issues"
 Source = "https://pypi.org/project/shepherd-core/"
 
 [build-system]

--- a/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/content/virtual_source_fixture.yaml
@@ -1,6 +1,6 @@
 # info:
 # - compendium of all parameters & description
-# - base for neutral fallback values if provided yml is sparse
+# - base for neutral fallback values if provided yaml is sparse
 # - -> it is encouraged to omit redundant parameters
 ---
 - datatype: VirtualSourceConfig

--- a/shepherd_core/shepherd_core/data_models/testbed/cape_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/cape_fixture.yaml
@@ -1,7 +1,7 @@
 ---
 
 # more human-readable test-protocol @
-# https://github.com/orgua/shepherd_v2_planning/blob/main/doc_testbed/Cape_pre-deployment-tests.xlsx
+# https://github.com/orgua/shepherd-v2-planning/blob/main/doc_testbed/Cape_pre-deployment-tests.xlsx
 - datatype: cape
   parameters:
     id: 1270051

--- a/shepherd_core/shepherd_core/data_models/testbed/observer_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/observer_fixture.yaml
@@ -1,6 +1,6 @@
 ---
-# observer-cape-target-relation: https://github.com/orgua/shepherd_v2_planning/blob/main/doc_testbed/Cape_pre-deployment-tests.xlsx
-# network data: https://github.com/orgua/shepherd_v2_planning/blob/main/doc_testbed/ethernet_MAC_addresses_bbones.ods
+# observer-cape-target-relation: https://github.com/orgua/shepherd-v2-planning/blob/main/doc_testbed/Cape_pre-deployment-tests.xlsx
+# network data: https://github.com/orgua/shepherd-v2-planning/blob/main/doc_testbed/ethernet_MAC_addresses_bbones.ods
 - datatype: observer
   parameters:
     id: 0

--- a/shepherd_core/shepherd_core/data_models/testbed/target_fixture.old1
+++ b/shepherd_core/shepherd_core/data_models/testbed/target_fixture.old1
@@ -1,6 +1,6 @@
 ---
 # more human-readable test-protocol @
-# https://github.com/orgua/shepherd_v2_planning/blob/main/doc_testbed/Target_pre-deployment-tests.xlsx
+# https://github.com/orgua/shepherd-v2-planning/blob/main/doc_testbed/Target_pre-deployment-tests.xlsx
 - datatype: target
   parameters:
     id: 6  # Outer ID - selected by user for XP - can be rearranged

--- a/shepherd_core/shepherd_core/data_models/testbed/target_fixture.yaml
+++ b/shepherd_core/shepherd_core/data_models/testbed/target_fixture.yaml
@@ -1,6 +1,6 @@
 ---
 # more human-readable test-protocol @
-# https://github.com/orgua/shepherd_v2_planning/blob/main/doc_testbed/Target_pre-deployment-tests.xlsx
+# https://github.com/orgua/shepherd-v2-planning/blob/main/doc_testbed/Target_pre-deployment-tests.xlsx
 - datatype: target
   parameters:
     id: 2  # Outer ID - selected by user for XP - can be rearranged

--- a/shepherd_core/shepherd_core/data_models/testbed/testbed.py
+++ b/shepherd_core/shepherd_core/data_models/testbed/testbed.py
@@ -15,7 +15,6 @@ from shepherd_core.data_models.base.content import IdInt
 from shepherd_core.data_models.base.content import NameStr
 from shepherd_core.data_models.base.content import SafeStr
 from shepherd_core.data_models.base.shepherd import ShpModel
-from shepherd_core.logger import logger
 from shepherd_core.testbed_client import tb_client
 
 from .observer import Observer
@@ -45,11 +44,10 @@ class Testbed(ShpModel):
     @classmethod
     def query_database(cls, values: dict[str, Any]) -> dict[str, Any]:
         # allow instantiating an empty Testbed
-        #   -> query the first (and only) entry of client
+        #   -> query the first (and usually only) entry of client
         if len(values) == 0:
             ids = tb_client.query_ids(cls.__name__)
-            if len(ids) > 1:
-                logger.warning("More than one testbed defined?!?")
+            # warning for "More than one testbed defined?!?" if len(ids) > 1
             values = {"id": ids[0]}
 
         values, _ = tb_client.try_completing_model(cls.__name__, values)

--- a/shepherd_core/shepherd_core/testbed_client/cache_path.py
+++ b/shepherd_core/shepherd_core/testbed_client/cache_path.py
@@ -14,4 +14,4 @@ def _get_xdg_path(variable_name: str, default_path: Path) -> Path:
 user_path = Path("~").expanduser()
 
 cache_xdg_path = _get_xdg_path("XDG_CACHE_HOME", user_path / ".cache")
-cache_user_path = cache_xdg_path / "shepherd_datalib"
+cache_user_path = cache_xdg_path / "shepherd"

--- a/shepherd_core/tests/data_models/example_config_emulator.yaml
+++ b/shepherd_core/tests/data_models/example_config_emulator.yaml
@@ -1,5 +1,5 @@
 # This is an example configuration for shepherd.
-# Instead of modifying, better make a copy and name it config.yml
+# Instead of modifying, better make a copy and name it config.yaml
 # Behavior: emulate a BQ-Controller for target A, enable io-connection
 mode: emulator
 parameters:

--- a/shepherd_core/tests/data_models/example_config_harvester.yaml
+++ b/shepherd_core/tests/data_models/example_config_harvester.yaml
@@ -1,5 +1,5 @@
 # This is an example configuration for shepherd.
-# Instead of modifying, better make a copy and name it config.yml
+# Instead of modifying, better make a copy and name it config.yaml
 # Behavior: record data for 20s or until stopped by ctrl+c
 mode: harvester
 parameters:

--- a/shepherd_data/README.md
+++ b/shepherd_data/README.md
@@ -1,19 +1,19 @@
 # Shepherd-Data-Tool
 
-[![PyPiVersion](https://img.shields.io/pypi/v/shepherd_data.svg)](https://pypi.org/project/shepherd_data)
+[![PyPIVersion](https://img.shields.io/pypi/v/shepherd_data.svg)](https://pypi.org/project/shepherd_data)
 [![image](https://img.shields.io/pypi/pyversions/shepherd_data.svg)](https://pypi.python.org/pypi/shepherd-data)
-[![Pytest](https://github.com/orgua/shepherd-datalib/actions/workflows/py_unittest.yml/badge.svg)](https://github.com/orgua/shepherd-datalib/actions/workflows/py_unittest.yml)
+[![QA-Tests](https://github.com/nes-lab/shepherd-tools/actions/workflows/quality_assurance.yaml/badge.svg)](https://github.com/nes-lab/shepherd-tools/actions/workflows/quality_assurance.yaml)
 [![CodeStyle](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-**Main Documentation**: <https://orgua.github.io/shepherd>
+**Main Documentation**: <https://nes-lab.github.io/shepherd>
 
-**Source Code**: <https://github.com/orgua/shepherd-datalib>
+**Source Code**: <https://github.com/nes-lab/shepherd-tools>
 
-**Main Project**: <https://github.com/orgua/shepherd>
+**Main Project**: <https://github.com/nes-lab/shepherd>
 
 ---
 
-`shepherd-data` eases the handling of hdf5-recordings used by the [shepherd](https://github.com/orgua/shepherd)-testbed. Users can read, validate and create files and also extract, down-sample and plot information.
+`shepherd-data` eases the handling of hdf5-recordings used by the [shepherd](https://github.com/nes-lab/shepherd)-testbed. Users can read, validate and create files and also extract, down-sample and plot information.
 
 ## Installation
 
@@ -26,12 +26,12 @@ pip3 install shepherd-data -U
 For bleeding-edge-features or dev-work it is possible to install directly from GitHub-Sources (here `dev`-branch):
 
 ```Shell
-pip install git+https://github.com/orgua/shepherd-datalib.git@dev#subdirectory=shepherd_data -U
+pip install git+https://github.com/nes-lab/shepherd-tools.git@dev#subdirectory=shepherd_data -U
 ```
 
 ## More
 
-Please consult the [official documentation](https://orgua.github.io/shepherd) for more, it covers:
+Please consult the [official documentation](https://nes-lab.github.io/shepherd) for more, it covers:
 
 - general context
 - command-line interface

--- a/shepherd_data/pyproject.toml
+++ b/shepherd_data/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/orgua/shepherd-datalib/blob/main/README.md"
+Documentation = "https://github.com/nes-lab/shepherd-tools/blob/main/README.md"
 Issues = "https://pypi.org/project/shepherd-data/issues"
 Source = "https://pypi.org/project/shepherd-data/"
 


### PR DESCRIPTION
## new repo structure @ nes-lab

- shepherd
- shepherd-tools
- shepherd-nova
- shepherd-targets
- shepherd-webapi

## replacements

- orgua -> nes-lab
- shepherd-data
- shepherd-v2-planning -> shepherd_v2_planning
- webservice -> webapi
- datalib -> tools
- -data -> tools
- naming of shepherd-tools is user tools, or python-tools for the user
- yml -> yaml
- check name of workflows!
- target-lib, target-repo -> targets-repo
- QC, -> QA
- unittests -> often tests (build, install, unittests)
- Nova -> nova
- https://shepherd.cfaed.tu-dresden.de -> nova-landingpage
- PyPi -> PyPI
