### PR TITLE
Allow generating EEnvs for subsets of nodes independently

### DIFF
--- a/extra/eenv_generator/commons.py
+++ b/extra/eenv_generator/commons.py
@@ -28,58 +28,55 @@ class EEnvGenerator(ABC):
     The main method produces data for a specific time-frame for all nodes.
     """
 
-    def __init__(self, node_count: int, seed: int | None) -> None:
+    def __init__(self, node_count: int, seed: None | int | list[int]) -> None:
         self.node_count = node_count
-        if seed is not None:
-            self.rnd_gen = np.random.Generator(bit_generator=np.random.PCG64(seed))
+        self.rnd_gen = np.random.Generator(bit_generator=np.random.PCG64(seed))
 
     @abstractmethod
     def generate_iv_pairs(self, count: int) -> list[tuple[np.ndarray, np.ndarray]]:
         pass
 
+    def generate_h5_files(self, file_paths: list[Path], duration: float, chunk_size: int) -> None:
+        """Apply Generator to create valid shepherd files.
 
-def generate_h5_files(
-    output_dir: Path, duration: float, chunk_size: int, generator: EEnvGenerator
-) -> None:
-    """Apply Generator to create valid shepherd files.
+        All files are created in parallel with custom chunk-size and duration.
+        This function handles the file-format and other parameters.
+        The file stem is used as the hostname of the respective file.
+        """
+        with ExitStack() as stack:
+            # Prepare datafiles
+            file_handles: list[ShepherdWriter] = []
+            for file_path in file_paths:
+                writer = ShepherdWriter(
+                    file_path=file_path,
+                    compression=Compression.gzip1,
+                    mode="harvester",
+                    datatype=EnergyDType.ivtrace,  # IV-trace
+                    window_samples=0,  # 0 since dt is IV-trace
+                    cal_data=CalibrationSeries(
+                        # sheep can skip scaling if cal is ideal
+                        voltage=CalibrationPair(gain=1e-6, offset=0),
+                        current=CalibrationPair(gain=1e-9, offset=0),
+                    ),
+                    verbose=False,
+                )
+                file_handles.append(stack.enter_context(writer))
+                writer.store_hostname(file_path.stem)
 
-    All files are created in parallel with custom chunk-size and duration.
-    This function handles the file-format and other parameters.
-    """
-    with ExitStack() as stack:
-        # Prepare datafiles
-        file_handles: list[ShepherdWriter] = []
-        for i in range(generator.node_count):
-            writer = ShepherdWriter(
-                file_path=output_dir / f"node{i}.h5",
-                compression=Compression.gzip1,
-                mode="harvester",
-                datatype=EnergyDType.ivtrace,  # IV-trace
-                window_samples=0,  # 0 since dt is IV-trace
-                cal_data=CalibrationSeries(
-                    # sheep can skip scaling if cal is ideal
-                    voltage=CalibrationPair(gain=1e-6, offset=0),
-                    current=CalibrationPair(gain=1e-9, offset=0),
-                ),
-                verbose=False,
-            )
-            file_handles.append(stack.enter_context(writer))
-            writer.store_hostname(f"node{i}.h5")
+            log.info("Generating energy environment...")
+            chunk_duration = chunk_size * STEP_WIDTH
+            chunk_count = math.ceil(duration / chunk_duration)
+            times_per_chunk = np.arange(0, chunk_size) * STEP_WIDTH
 
-        log.info("Generating energy environment...")
-        chunk_duration = chunk_size * STEP_WIDTH
-        chunk_count = math.ceil(duration / chunk_duration)
-        times_per_chunk = np.arange(0, chunk_size) * STEP_WIDTH
+            start_time = time.time()
+            for i in trange(chunk_count, desc="Generating chunk: ", leave=False):
+                times_unfiltered = chunk_duration * i + times_per_chunk
+                times = times_unfiltered[np.where(times_unfiltered <= duration)]
+                count = len(times)
 
-        start_time = time.time()
-        for i in trange(chunk_count, desc="Generating chunk: ", leave=False):
-            times_unfiltered = chunk_duration * i + times_per_chunk
-            times = times_unfiltered[np.where(times_unfiltered <= duration)]
-            count = len(times)
+                iv_pairs = self.generate_iv_pairs(count=count)
 
-            iv_pairs = generator.generate_iv_pairs(count=count)
-
-            for file, (voltages, currents) in zip(file_handles, iv_pairs, strict=False):
-                file.append_iv_data_si(times, voltages, currents)
-        end_time = time.time()
-        log.info("Done! Generation took %.2f s", end_time - start_time)
+                for file, (voltages, currents) in zip(file_handles, iv_pairs, strict=True):
+                    file.append_iv_data_si(times, voltages, currents)
+            end_time = time.time()
+            log.info("Done! Generation took %.2f s", end_time - start_time)

--- a/extra/eenv_generator/ivtraces_onpattern_random_independent.py
+++ b/extra/eenv_generator/ivtraces_onpattern_random_independent.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import numpy as np
 from commons import STEP_WIDTH
 from commons import EEnvGenerator
-from commons import generate_h5_files
 
 from shepherd_core.logger import log
 
@@ -21,7 +20,7 @@ class RndIndepPatternGenerator(EEnvGenerator):
     def __init__(
         self,
         node_count: int,
-        seed: int,
+        seed: None | int | list[int],
         avg_duty_cycle: float,
         avg_on_duration: float,
         on_voltage: float,
@@ -72,30 +71,52 @@ if __name__ == "__main__":
     else:
         path_eenv = path_here / "content/eenv/nes_lab/"
 
-    seed = 32220789340897324098232347119065234157809
     duty_cycles = [0.01, 0.02, 0.05, 0.1, 0.2]
     on_durations = [100e-6, 500e-6, 1e-3, 5e-3]
     duration = 4 * 60 * 60.0
 
-    for duty_cycle, on_duration in product(duty_cycles, on_durations):
-        generator = RndIndepPatternGenerator(
-            node_count=20,
-            seed=seed,
-            avg_duty_cycle=duty_cycle,
-            avg_on_duration=on_duration,
-            on_voltage=2.0,
-            on_current=10e-3,
-        )
+    node_count = 20
+    seed = 32220789340897324098232347119065234157809
+    chunk_size = 10_000_000
 
-        # Create output folder (or skip)
+    for duty_cycle, on_duration in product(duty_cycles, on_durations):
+        # Ensure output folder exists
         name = (
             "artificial_on_off_random_markov_avg_"
             f"{round(duty_cycle * 100.0)}%_{round(on_duration * 1e6)}us"
         )
         folder_path = path_eenv / name
-        if folder_path.exists():
-            log.info("Folder %s exists. Skipping combination.", folder_path)
-            continue
-        folder_path.mkdir(parents=True, exist_ok=False)
 
-        generate_h5_files(folder_path, duration=duration, chunk_size=500_000, generator=generator)
+        if folder_path.exists():
+            log.warning("Folder %s exists. New node files will be added.", folder_path)
+        folder_path.mkdir(parents=True, exist_ok=True)
+
+        # Generate EEnv for this combination
+        # Note: Nodes are generated independently to allow adding
+        #       nodes without re-generating existing ones
+        log.info("Generating EEnv: %s", name)
+        for node_idx in range(node_count):
+            node_path = folder_path / f"node{node_idx}.h5"
+            if node_path.exists():
+                log.info("File %s exists. Skipping node %i.", node_path, node_idx)
+                continue
+
+            generator = RndIndepPatternGenerator(
+                node_count=1,
+                seed=[seed, node_idx],
+                avg_duty_cycle=duty_cycle,
+                avg_on_duration=on_duration,
+                on_voltage=2.0,
+                on_current=10e-3,
+            )
+
+            try:
+                generator.generate_h5_files(
+                    file_paths=[node_path], duration=duration, chunk_size=chunk_size
+                )
+            except:
+                # Ensure no unfinished node files remain on exception/interrupt
+                # These would be skipped when re-executing, resulting in a broken EEnv
+                log.error("Exception encountered. Removing incomplete node file: %s", node_path)
+                node_path.unlink()
+                raise

--- a/extra/eenv_generator/ivtraces_onpattern_random_independent.py
+++ b/extra/eenv_generator/ivtraces_onpattern_random_independent.py
@@ -40,19 +40,22 @@ class RndIndepPatternGenerator(EEnvGenerator):
 
     def generate_random_pattern(self, count: int) -> np.ndarray:
         samples = np.zeros((count, self.node_count))
+        # Pre-Generate random matrix (steps x nodes)
+        random = self.rnd_gen.random((count, self.node_count))
+
+        # Start from last states (from last chunk)
+        last_states = self.states
 
         for i in range(count):
-            # Start from last states
-            last_states = samples[i - 1] if i > 0 else self.states
-            # Generate random vector (1 value per node)
-            random = self.rnd_gen.random(self.node_count)
             # Get probability vector
             probabilities = self.transition_probs[last_states.astype(int)]
             # Generate updated states
-            samples[i] = random < probabilities
+            samples[i] = random[i] < probabilities
+            # Save state for next transition
+            last_states = samples[i]
 
         # Save last states for next chunk
-        self.states = samples[len(samples) - 1]
+        self.states = last_states
 
         return samples
 


### PR DESCRIPTION
Previously, during EEnv generation, all nodes shared a single random seed. This meant that changing the number of nodes (such as adding a single one) would affect the data of all nodes.
Therefore, adding nodes later on would have required regenerating all existing data.

These changes allow generating the nodes independently. The data no longer depends on the configured node count.
Re-executing the scripts will now skip nodes with existing data.